### PR TITLE
fix(agent): trust configured CA bundle instead of disabling TLS verification (#47)

### DIFF
--- a/agent/llm.py
+++ b/agent/llm.py
@@ -167,13 +167,18 @@ def _create_client(api_key: str) -> OpenAI:
     When running behind a corporate proxy that performs TLS inspection,
     set the ``SSL_CERT_FILE`` or ``REQUESTS_CA_BUNDLE`` environment
     variable to point to a CA bundle that includes the proxy's root CA.
+    That bundle is used to **verify** the connection — certificate
+    verification is never disabled.
     """
     if api_key not in _client_cache:
         ca_bundle = os.environ.get("SSL_CERT_FILE") or os.environ.get(
             "REQUESTS_CA_BUNDLE"
         )
         if ca_bundle:
-            http_client = httpx.Client(verify=False)
+            # Trust the supplied CA bundle (e.g. a TLS-inspecting proxy's root
+            # CA). Do NOT disable verification — that would expose the API key
+            # and query results to any on-path attacker.
+            http_client = httpx.Client(verify=ca_bundle)
             _client_cache[api_key] = OpenAI(api_key=api_key, http_client=http_client)
         else:
             _client_cache[api_key] = OpenAI(api_key=api_key)

--- a/agent/tests/test_llm.py
+++ b/agent/tests/test_llm.py
@@ -557,3 +557,40 @@ def test_generate_analysis_retries_on_server_error(mock_openai_client):
 
     assert "Analysis" in result
     mock_sleep.assert_called_once_with(1.0)
+
+
+# ---------------------------------------------------------------------------
+# TLS verification (issue #47): a custom CA bundle must be trusted, not bypassed
+# ---------------------------------------------------------------------------
+
+
+def test_create_client_uses_ca_bundle_for_verification():
+    """A configured CA bundle is passed to httpx verify=, never verify=False."""
+    _clear_client_cache()
+    with (
+        patch("llm.OpenAI") as mock_openai,
+        patch("llm.httpx.Client") as mock_httpx,
+        patch.dict(
+            "os.environ", {"SSL_CERT_FILE": "/etc/ssl/proxy-ca.pem"}, clear=False
+        ),
+    ):
+        mock_openai.return_value = MagicMock()
+        _create_client("sk-ca-test")
+
+    mock_httpx.assert_called_once_with(verify="/etc/ssl/proxy-ca.pem")
+    # Guard against a regression back to verify=False.
+    assert mock_httpx.call_args.kwargs.get("verify") is not False
+
+
+def test_create_client_no_ca_bundle_uses_default_client():
+    """With no CA bundle configured, no custom (unverified) http_client is built."""
+    _clear_client_cache()
+    with (
+        patch("llm.OpenAI") as mock_openai,
+        patch("llm.httpx.Client") as mock_httpx,
+        patch.dict("os.environ", {}, clear=True),
+    ):
+        mock_openai.return_value = MagicMock()
+        _create_client("sk-no-ca")
+
+    mock_httpx.assert_not_called()


### PR DESCRIPTION
Fixes #47.

## Problem
`agent/llm.py:_create_client` disabled TLS certificate verification for **all** OpenAI API calls whenever a custom CA bundle was configured:

```python
if ca_bundle:
    http_client = httpx.Client(verify=False)   # ignores ca_bundle, disables verification
```

The docstring's intent is to *trust* the proxy's CA bundle, but the code passed `verify=False` and ignored `ca_bundle` entirely. Every request — carrying the **OpenAI API key** and the **CloudTrail query results/analysis** — was sent with no certificate verification, allowing any on-path attacker to MITM (steal the key, read/alter traffic). This hits exactly the corporate-proxy users the branch was meant to help.

## Fix
Pass the CA bundle to `verify=` instead:

```python
if ca_bundle:
    http_client = httpx.Client(verify=ca_bundle)
```

## Tests
- `test_create_client_uses_ca_bundle_for_verification` — asserts `httpx.Client(verify=<bundle path>)` and guards against a regression to `verify=False`.
- `test_create_client_no_ca_bundle_uses_default_client` — no custom client when no bundle is set.

`test_llm.py`: 51 passed. `ruff` clean, `black` formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
