### PR TITLE
ci: pin all GitHub Actions to commit SHAs & add Dependabot (#50)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  # Keep the SHA-pinned GitHub Actions current with automated bump PRs so that
+  # pinning to immutable commits does not leave the workflows stuck on old,
+  # potentially vulnerable action versions.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,12 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install stable Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           components: clippy, rustfmt
 
       - name: Free up disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: false
           android: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,12 +25,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.x"
           cache: pip
@@ -42,10 +42,10 @@ jobs:
         run: mkdocs build --strict --config-file website/mkdocs.yml
 
       - name: Configure Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: website/site
 
@@ -58,4 +58,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,10 +46,10 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install stable Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
 
       - name: Free up disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: false
           android: true


### PR DESCRIPTION
Fixes #50.

## Problem
Some third-party actions were referenced by **mutable refs**:
- `dtolnay/rust-toolchain@stable` (release.yml, ci.yml)
- `jlumbroso/free-disk-space@main` (ci.yml)
- `actions/*@v7`/`@v6`/`@v5` (docs.yml)

If an upstream action is compromised or its tag/branch is force-moved (a recurring real-world attack), attacker code runs in a job with `contents: write` — the release job builds & uploads the `ingester-*-linux` binary that every default Docker build downloads and runs, and can exfiltrate CI caches/secrets.

## Fix
Pin every third-party action to a full commit SHA (matching the already-pinned `actions/checkout`, `actions/setup-python`, `Swatinem/rust-cache`, etc.):

| Action | SHA | tag |
|---|---|---|
| dtolnay/rust-toolchain | `4cda84d…1699d4` | stable |
| jlumbroso/free-disk-space | `54081f1…a1be` | v1.3.1 |
| actions/checkout (docs) | `9c091bb…fe3e0` | v7.0.0 |
| actions/setup-python (docs) | `a309ff8…02405` | v6.2.0 |
| actions/configure-pages | `45bfe01…4a0d` | v6 |
| actions/upload-pages-artifact | `fc324d3…c49c9` | v5 |
| actions/deploy-pages | `cd2ce8f…fa128` | v5 |

Adds `.github/dependabot.yml` (`github-actions`, weekly) so pinned SHAs still get automated bump PRs. All workflow YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
