### PR TITLE
security(dashboard): remove Superset insecure defaults — secret key, CSRF, RW mount (#51)

### DIFF
--- a/dashboard/superset_config.py
+++ b/dashboard/superset_config.py
@@ -22,8 +22,20 @@ from sqlalchemy.dialects import registry  # noqa: E402
 registry.register("duckdb", "duckdb_engine", "Dialect")
 registry.register("duckdb.duckdb_engine", "duckdb_engine", "Dialect")
 
-# Secret key for session signing — MUST be overridden in production via env var.
-SECRET_KEY = os.environ.get("SUPERSET_SECRET_KEY", "change-me-in-production")
+# Secret key for session signing. There is NO safe default: a known key lets
+# anyone reachable on the port forge a valid signed admin session cookie without
+# the password. Require it to be set to a non-default value and refuse to boot
+# otherwise, so a missing/insecure key fails loudly instead of silently shipping
+# a publicly-known one.
+_INSECURE_DEFAULT_SECRET_KEY = "change-me-in-production"  # noqa: S105
+SECRET_KEY = os.environ.get("SUPERSET_SECRET_KEY", "")
+if not SECRET_KEY or SECRET_KEY == _INSECURE_DEFAULT_SECRET_KEY:
+    raise SystemExit(
+        "SUPERSET_SECRET_KEY is unset or still the insecure default. "
+        "Generate a unique value and set it in docker/.env before starting "
+        'Superset, e.g.:  echo "SUPERSET_SECRET_KEY=$(openssl rand -base64 42)" '
+        ">> docker/.env"
+    )
 
 # Superset home directory for metadata DB, uploads, etc.
 DATA_DIR = "/app/superset_home"
@@ -37,8 +49,11 @@ SUPERSET_LOAD_EXAMPLES = False
 # Prevent connections to unsafe internal/metadata databases.
 PREVENT_UNSAFE_DB_CONNECTIONS = True
 
-# CSRF — disable for local development convenience (re-enable for production).
-WTF_CSRF_ENABLED = False
+# CSRF protection — enabled so a malicious web page the analyst visits cannot
+# drive state-changing requests against Superset on localhost. The one-shot
+# init/resync scripts use the in-process Python API (not HTTP forms), so this
+# does not affect them.
+WTF_CSRF_ENABLED = True
 
 # Chart query results cache — FileSystemCache persists across container restarts via
 # the superset_home named volume.  Data is static between ingester runs, so 8 h TTL

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -60,5 +60,11 @@ RUST_LOG=info
 # OPENAI_API_KEY=
 
 # ── Superset ────────────────────────────────────────
-# Secret key for Superset (change in production!)
-SUPERSET_SECRET_KEY=change-me-in-production
+# REQUIRED: secret key that signs Superset session cookies. There is no safe
+# default — a known key lets anyone reachable on port 8088 forge an admin
+# session. Superset refuses to start until you set a unique value here.
+# Generate one with:  openssl rand -base64 42
+SUPERSET_SECRET_KEY=
+# Change the default Superset admin password before exposing the dashboard
+# beyond localhost (defaults to "admin" if unset).
+# SUPERSET_ADMIN_PASSWORD=

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,7 +8,7 @@
 
 x-superset-image: &superset-image senrigan-dashboard:latest
 x-superset-env: &superset-env
-  SUPERSET_SECRET_KEY: ${SUPERSET_SECRET_KEY:-change-me-in-production}
+  SUPERSET_SECRET_KEY: "${SUPERSET_SECRET_KEY:?set SUPERSET_SECRET_KEY in .env (generate with openssl rand -base64 42)}"
   DUCKDB_PATH: /data/db/threat_hunting.db
 x-ca-cert-arg: &ca-cert-arg
   CUSTOM_CA_CERT_BASE64: ${CUSTOM_CA_CERT_BASE64:-}
@@ -101,7 +101,9 @@ services:
     ports:
       - "127.0.0.1:8088:8088"
     volumes:
-      - ${DUCKDB_HOST_PATH:-./data/db}:/data/db
+      # Superset only reads the DuckDB file — mount read-only (least privilege),
+      # matching the agent/config-viz reader services.
+      - ${DUCKDB_HOST_PATH:-./data/db}:/data/db:ro
       - superset_home:/app/superset_home
       - ../dashboard/assets:/app/dashboards:ro
       - ../dashboard/superset_config.py:/app/pythonpath/superset_config.py:ro
@@ -121,7 +123,8 @@ services:
     image: *superset-image
     container_name: threat-hunting-superset-init
     volumes:
-      - ${DUCKDB_HOST_PATH:-./data/db}:/data/db
+      # Init only registers datasets/dashboards; it never writes the DuckDB file.
+      - ${DUCKDB_HOST_PATH:-./data/db}:/data/db:ro
       - superset_home:/app/superset_home
       - ../dashboard/assets:/app/dashboards:ro
       - ../dashboard/superset_config.py:/app/pythonpath/superset_config.py:ro


### PR DESCRIPTION
Fixes #51.

## Problem
Superset shipped insecure defaults that become dangerous the moment the service leaves `127.0.0.1`:
- `SECRET_KEY = os.environ.get("SUPERSET_SECRET_KEY", "change-me-in-production")` — a **publicly-known** signing key. Anyone reaching port 8088 can forge a valid admin session cookie without the password.
- `WTF_CSRF_ENABLED = False`.
- `superset`/`superset-init` mounted `/data/db` **read-write**, unlike the other reader services.

## Fix
- **`superset_config.py`**: refuse to boot (`SystemExit`) when `SUPERSET_SECRET_KEY` is unset/empty or still the known default — no safe fallback. Enable `WTF_CSRF_ENABLED` (the init/resync scripts use the in-process Python API, not HTTP forms, so they're unaffected).
- **`docker-compose.yml`**: require the secret via `${SUPERSET_SECRET_KEY:?…}` (compose fails fast with a generation hint); mount `/data/db` **`:ro`** for `superset` and `superset-init`. The `ingester` stays read-write as the sole writer.
- **`.env.example`**: document generating the secret (`openssl rand -base64 42`) and changing the admin password before non-localhost exposure.

## Notes / tests
- `test_superset_config.py` parses the file with `ast` (never executes it), so the new boot-time guard doesn't affect it — **8 passed**. No test asserted the old `WTF_CSRF_ENABLED=False`/default key.
- Mount audit: ingester `/data/db` (rw, sole writer) unchanged; all readers now `:ro`.
- **Behaviour change:** first run now requires setting `SUPERSET_SECRET_KEY` in `.env` (fails fast with instructions) instead of silently booting on the known key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
