### PR TITLE
docs: add DEF CON 2026 badge to README and docs landing pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
     <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue.svg"></a>
     <a href="https://github.com/Yamato-Security/senrigan/actions/workflows/ci.yml"><img src="https://github.com/Yamato-Security/senrigan/actions/workflows/ci.yml/badge.svg"></a>
     <a href="docker/docker-compose.yml"><img src="https://img.shields.io/badge/docker-compose-blue"></a>
+    <a href="https://defcon.org/html/defcon-34/dc-34-demolabs.html#content_66521"><img src="https://img.shields.io/badge/DEFCON-2026-red"></a>
     <a href="https://twitter.com/SecurityYamato"><img src="https://img.shields.io/twitter/follow/SecurityYamato?style=social"/></a>
  </p>
 

--- a/website/docs/index.ar.md
+++ b/website/docs/index.ar.md
@@ -25,6 +25,7 @@ CloudTrail الخاصة بك واحصل على <strong>أكثر من 100 عمل�
 <a href="https://github.com/Yamato-Security/senrigan/stargazers"><img src="https://img.shields.io/github/stars/Yamato-Security/senrigan?style=flat&label=GitHub%F0%9F%A6%85Stars"/></a>
 <a href="https://github.com/Yamato-Security/senrigan/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-AGPLv3-blue.svg?style=flat"/></a>
 <a href="https://github.com/Yamato-Security/senrigan/blob/main/docker/docker-compose.yml"><img src="https://img.shields.io/badge/docker-compose-blue"></a>
+<a href="https://defcon.org/html/defcon-34/dc-34-demolabs.html#content_66521"><img src="https://img.shields.io/badge/DEFCON-2026-red"></a>
 <a href="https://twitter.com/SecurityYamato"><img src="https://img.shields.io/twitter/follow/SecurityYamato?style=social"/></a>
 </p>
 

--- a/website/docs/index.de.md
+++ b/website/docs/index.de.md
@@ -25,6 +25,7 @@ Laptop mit einem einzigen <code>make up</code>. Kein SIEM erforderlich, keine Cl
 <a href="https://github.com/Yamato-Security/senrigan/stargazers"><img src="https://img.shields.io/github/stars/Yamato-Security/senrigan?style=flat&label=GitHub%F0%9F%A6%85Stars"/></a>
 <a href="https://github.com/Yamato-Security/senrigan/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-AGPLv3-blue.svg?style=flat"/></a>
 <a href="https://github.com/Yamato-Security/senrigan/blob/main/docker/docker-compose.yml"><img src="https://img.shields.io/badge/docker-compose-blue"></a>
+<a href="https://defcon.org/html/defcon-34/dc-34-demolabs.html#content_66521"><img src="https://img.shields.io/badge/DEFCON-2026-red"></a>
 <a href="https://twitter.com/SecurityYamato"><img src="https://img.shields.io/twitter/follow/SecurityYamato?style=social"/></a>
 </p>
 

--- a/website/docs/index.es.md
+++ b/website/docs/index.es.md
@@ -25,6 +25,7 @@ portátil con un solo <code>make up</code>. Sin necesidad de SIEM ni de infraest
 <a href="https://github.com/Yamato-Security/senrigan/stargazers"><img src="https://img.shields.io/github/stars/Yamato-Security/senrigan?style=flat&label=GitHub%F0%9F%A6%85Stars"/></a>
 <a href="https://github.com/Yamato-Security/senrigan/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-AGPLv3-blue.svg?style=flat"/></a>
 <a href="https://github.com/Yamato-Security/senrigan/blob/main/docker/docker-compose.yml"><img src="https://img.shields.io/badge/docker-compose-blue"></a>
+<a href="https://defcon.org/html/defcon-34/dc-34-demolabs.html#content_66521"><img src="https://img.shields.io/badge/DEFCON-2026-red"></a>
 <a href="https://twitter.com/SecurityYamato"><img src="https://img.shields.io/twitter/follow/SecurityYamato?style=social"/></a>
 </p>
 

--- a/website/docs/index.fr.md
+++ b/website/docs/index.fr.md
@@ -27,6 +27,7 @@ ordinateur portable avec une seule commande <code>make up</code>. Aucun SIEM req
 <a href="https://github.com/Yamato-Security/senrigan/stargazers"><img src="https://img.shields.io/github/stars/Yamato-Security/senrigan?style=flat&label=GitHub%F0%9F%A6%85Stars"/></a>
 <a href="https://github.com/Yamato-Security/senrigan/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-AGPLv3-blue.svg?style=flat"/></a>
 <a href="https://github.com/Yamato-Security/senrigan/blob/main/docker/docker-compose.yml"><img src="https://img.shields.io/badge/docker-compose-blue"></a>
+<a href="https://defcon.org/html/defcon-34/dc-34-demolabs.html#content_66521"><img src="https://img.shields.io/badge/DEFCON-2026-red"></a>
 <a href="https://twitter.com/SecurityYamato"><img src="https://img.shields.io/twitter/follow/SecurityYamato?style=social"/></a>
 </p>
 

--- a/website/docs/index.hi.md
+++ b/website/docs/index.hi.md
@@ -27,6 +27,7 @@ CloudTrail लॉग डालें और पाएं <strong>100+ तैय�
 <a href="https://github.com/Yamato-Security/senrigan/stargazers"><img src="https://img.shields.io/github/stars/Yamato-Security/senrigan?style=flat&label=GitHub%F0%9F%A6%85Stars"/></a>
 <a href="https://github.com/Yamato-Security/senrigan/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-AGPLv3-blue.svg?style=flat"/></a>
 <a href="https://github.com/Yamato-Security/senrigan/blob/main/docker/docker-compose.yml"><img src="https://img.shields.io/badge/docker-compose-blue"></a>
+<a href="https://defcon.org/html/defcon-34/dc-34-demolabs.html#content_66521"><img src="https://img.shields.io/badge/DEFCON-2026-red"></a>
 <a href="https://twitter.com/SecurityYamato"><img src="https://img.shields.io/twitter/follow/SecurityYamato?style=social"/></a>
 </p>
 

--- a/website/docs/index.id.md
+++ b/website/docs/index.id.md
@@ -25,6 +25,7 @@ laptop Anda hanya dengan satu <code>make up</code>. Tanpa SIEM, tanpa infrastruk
 <a href="https://github.com/Yamato-Security/senrigan/stargazers"><img src="https://img.shields.io/github/stars/Yamato-Security/senrigan?style=flat&label=GitHub%F0%9F%A6%85Stars"/></a>
 <a href="https://github.com/Yamato-Security/senrigan/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-AGPLv3-blue.svg?style=flat"/></a>
 <a href="https://github.com/Yamato-Security/senrigan/blob/main/docker/docker-compose.yml"><img src="https://img.shields.io/badge/docker-compose-blue"></a>
+<a href="https://defcon.org/html/defcon-34/dc-34-demolabs.html#content_66521"><img src="https://img.shields.io/badge/DEFCON-2026-red"></a>
 <a href="https://twitter.com/SecurityYamato"><img src="https://img.shields.io/twitter/follow/SecurityYamato?style=social"/></a>
 </p>
 

--- a/website/docs/index.ja.md
+++ b/website/docs/index.ja.md
@@ -27,6 +27,7 @@ hide:
 <a href="https://github.com/Yamato-Security/senrigan/stargazers"><img src="https://img.shields.io/github/stars/Yamato-Security/senrigan?style=flat&label=GitHub%F0%9F%A6%85Stars"/></a>
 <a href="https://github.com/Yamato-Security/senrigan/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-AGPLv3-blue.svg?style=flat"/></a>
 <a href="https://github.com/Yamato-Security/senrigan/blob/main/docker/docker-compose.yml"><img src="https://img.shields.io/badge/docker-compose-blue"></a>
+<a href="https://defcon.org/html/defcon-34/dc-34-demolabs.html#content_66521"><img src="https://img.shields.io/badge/DEFCON-2026-red"></a>
 <a href="https://twitter.com/SecurityYamato"><img src="https://img.shields.io/twitter/follow/SecurityYamato?style=social"/></a>
 </p>
 

--- a/website/docs/index.ko.md
+++ b/website/docs/index.ko.md
@@ -25,6 +25,7 @@ hide:
 <a href="https://github.com/Yamato-Security/senrigan/stargazers"><img src="https://img.shields.io/github/stars/Yamato-Security/senrigan?style=flat&label=GitHub%F0%9F%A6%85Stars"/></a>
 <a href="https://github.com/Yamato-Security/senrigan/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-AGPLv3-blue.svg?style=flat"/></a>
 <a href="https://github.com/Yamato-Security/senrigan/blob/main/docker/docker-compose.yml"><img src="https://img.shields.io/badge/docker-compose-blue"></a>
+<a href="https://defcon.org/html/defcon-34/dc-34-demolabs.html#content_66521"><img src="https://img.shields.io/badge/DEFCON-2026-red"></a>
 <a href="https://twitter.com/SecurityYamato"><img src="https://img.shields.io/twitter/follow/SecurityYamato?style=social"/></a>
 </p>
 

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -27,6 +27,7 @@ laptop with a single <code>make up</code>. No SIEM required, no cloud infrastruc
 <a href="https://github.com/Yamato-Security/senrigan/stargazers"><img src="https://img.shields.io/github/stars/Yamato-Security/senrigan?style=flat&label=GitHub%F0%9F%A6%85Stars"/></a>
 <a href="https://github.com/Yamato-Security/senrigan/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-AGPLv3-blue.svg?style=flat"/></a>
 <a href="https://github.com/Yamato-Security/senrigan/blob/main/docker/docker-compose.yml"><img src="https://img.shields.io/badge/docker-compose-blue"></a>
+<a href="https://defcon.org/html/defcon-34/dc-34-demolabs.html#content_66521"><img src="https://img.shields.io/badge/DEFCON-2026-red"></a>
 <a href="https://twitter.com/SecurityYamato"><img src="https://img.shields.io/twitter/follow/SecurityYamato?style=social"/></a>
 </p>
 

--- a/website/docs/index.my.md
+++ b/website/docs/index.my.md
@@ -23,6 +23,7 @@ hide:
 <a href="https://github.com/Yamato-Security/senrigan/stargazers"><img src="https://img.shields.io/github/stars/Yamato-Security/senrigan?style=flat&label=GitHub%F0%9F%A6%85Stars"/></a>
 <a href="https://github.com/Yamato-Security/senrigan/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-AGPLv3-blue.svg?style=flat"/></a>
 <a href="https://github.com/Yamato-Security/senrigan/blob/main/docker/docker-compose.yml"><img src="https://img.shields.io/badge/docker-compose-blue"></a>
+<a href="https://defcon.org/html/defcon-34/dc-34-demolabs.html#content_66521"><img src="https://img.shields.io/badge/DEFCON-2026-red"></a>
 <a href="https://twitter.com/SecurityYamato"><img src="https://img.shields.io/twitter/follow/SecurityYamato?style=social"/></a>
 </p>
 

--- a/website/docs/index.pt-BR.md
+++ b/website/docs/index.pt-BR.md
@@ -25,6 +25,7 @@ laptop com um único <code>make up</code>. Sem necessidade de SIEM, sem necessid
 <a href="https://github.com/Yamato-Security/senrigan/stargazers"><img src="https://img.shields.io/github/stars/Yamato-Security/senrigan?style=flat&label=GitHub%F0%9F%A6%85Stars"/></a>
 <a href="https://github.com/Yamato-Security/senrigan/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-AGPLv3-blue.svg?style=flat"/></a>
 <a href="https://github.com/Yamato-Security/senrigan/blob/main/docker/docker-compose.yml"><img src="https://img.shields.io/badge/docker-compose-blue"></a>
+<a href="https://defcon.org/html/defcon-34/dc-34-demolabs.html#content_66521"><img src="https://img.shields.io/badge/DEFCON-2026-red"></a>
 <a href="https://twitter.com/SecurityYamato"><img src="https://img.shields.io/twitter/follow/SecurityYamato?style=social"/></a>
 </p>
 

--- a/website/docs/index.th.md
+++ b/website/docs/index.th.md
@@ -26,6 +26,7 @@ hide:
 <a href="https://github.com/Yamato-Security/senrigan/stargazers"><img src="https://img.shields.io/github/stars/Yamato-Security/senrigan?style=flat&label=GitHub%F0%9F%A6%85Stars"/></a>
 <a href="https://github.com/Yamato-Security/senrigan/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-AGPLv3-blue.svg?style=flat"/></a>
 <a href="https://github.com/Yamato-Security/senrigan/blob/main/docker/docker-compose.yml"><img src="https://img.shields.io/badge/docker-compose-blue"></a>
+<a href="https://defcon.org/html/defcon-34/dc-34-demolabs.html#content_66521"><img src="https://img.shields.io/badge/DEFCON-2026-red"></a>
 <a href="https://twitter.com/SecurityYamato"><img src="https://img.shields.io/twitter/follow/SecurityYamato?style=social"/></a>
 </p>
 

--- a/website/docs/index.tr.md
+++ b/website/docs/index.tr.md
@@ -27,6 +27,7 @@ dizüstü bilgisayarınızda tek bir <code>make up</code> ile. SIEM gerekmez, bu
 <a href="https://github.com/Yamato-Security/senrigan/stargazers"><img src="https://img.shields.io/github/stars/Yamato-Security/senrigan?style=flat&label=GitHub%F0%9F%A6%85Stars"/></a>
 <a href="https://github.com/Yamato-Security/senrigan/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-AGPLv3-blue.svg?style=flat"/></a>
 <a href="https://github.com/Yamato-Security/senrigan/blob/main/docker/docker-compose.yml"><img src="https://img.shields.io/badge/docker-compose-blue"></a>
+<a href="https://defcon.org/html/defcon-34/dc-34-demolabs.html#content_66521"><img src="https://img.shields.io/badge/DEFCON-2026-red"></a>
 <a href="https://twitter.com/SecurityYamato"><img src="https://img.shields.io/twitter/follow/SecurityYamato?style=social"/></a>
 </p>
 

--- a/website/docs/index.uk.md
+++ b/website/docs/index.uk.md
@@ -26,6 +26,7 @@ Superset</strong>, аналіз із підтримкою ШІ та граф р�
 <a href="https://github.com/Yamato-Security/senrigan/stargazers"><img src="https://img.shields.io/github/stars/Yamato-Security/senrigan?style=flat&label=GitHub%F0%9F%A6%85Stars"/></a>
 <a href="https://github.com/Yamato-Security/senrigan/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-AGPLv3-blue.svg?style=flat"/></a>
 <a href="https://github.com/Yamato-Security/senrigan/blob/main/docker/docker-compose.yml"><img src="https://img.shields.io/badge/docker-compose-blue"></a>
+<a href="https://defcon.org/html/defcon-34/dc-34-demolabs.html#content_66521"><img src="https://img.shields.io/badge/DEFCON-2026-red"></a>
 <a href="https://twitter.com/SecurityYamato"><img src="https://img.shields.io/twitter/follow/SecurityYamato?style=social"/></a>
 </p>
 

--- a/website/docs/index.zh-TW.md
+++ b/website/docs/index.zh-TW.md
@@ -25,6 +25,7 @@ CloudTrail 日誌，即可取得<strong>超過 100 種可立即執行的威脅�
 <a href="https://github.com/Yamato-Security/senrigan/stargazers"><img src="https://img.shields.io/github/stars/Yamato-Security/senrigan?style=flat&label=GitHub%F0%9F%A6%85Stars"/></a>
 <a href="https://github.com/Yamato-Security/senrigan/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-AGPLv3-blue.svg?style=flat"/></a>
 <a href="https://github.com/Yamato-Security/senrigan/blob/main/docker/docker-compose.yml"><img src="https://img.shields.io/badge/docker-compose-blue"></a>
+<a href="https://defcon.org/html/defcon-34/dc-34-demolabs.html#content_66521"><img src="https://img.shields.io/badge/DEFCON-2026-red"></a>
 <a href="https://twitter.com/SecurityYamato"><img src="https://img.shields.io/twitter/follow/SecurityYamato?style=social"/></a>
 </p>
 

--- a/website/docs/overview/index.ar.md
+++ b/website/docs/overview/index.ar.md
@@ -7,6 +7,7 @@
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](https://github.com/Yamato-Security/senrigan/blob/main/LICENSE)
 [![CI](https://github.com/Yamato-Security/senrigan/actions/workflows/ci.yml/badge.svg)](https://github.com/Yamato-Security/senrigan/actions/workflows/ci.yml)
 [![Docker](https://img.shields.io/badge/docker-compose-blue)](https://github.com/Yamato-Security/senrigan/blob/main/docker/docker-compose.yml)
+[![DEFCON](https://img.shields.io/badge/DEFCON-2026-red)](https://defcon.org/html/defcon-34/dc-34-demolabs.html#content_66521)
 [![Rust](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](https://github.com/Yamato-Security/senrigan/blob/main/ingester/Cargo.toml)
 [![Python](https://img.shields.io/badge/python-3.14%2B-blue.svg)](https://github.com/Yamato-Security/senrigan/blob/main/agent/requirements.txt)
 

--- a/website/docs/overview/index.de.md
+++ b/website/docs/overview/index.de.md
@@ -7,6 +7,7 @@
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](https://github.com/Yamato-Security/senrigan/blob/main/LICENSE)
 [![CI](https://github.com/Yamato-Security/senrigan/actions/workflows/ci.yml/badge.svg)](https://github.com/Yamato-Security/senrigan/actions/workflows/ci.yml)
 [![Docker](https://img.shields.io/badge/docker-compose-blue)](https://github.com/Yamato-Security/senrigan/blob/main/docker/docker-compose.yml)
+[![DEFCON](https://img.shields.io/badge/DEFCON-2026-red)](https://defcon.org/html/defcon-34/dc-34-demolabs.html#content_66521)
 [![Rust](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](https://github.com/Yamato-Security/senrigan/blob/main/ingester/Cargo.toml)
 [![Python](https://img.shields.io/badge/python-3.14%2B-blue.svg)](https://github.com/Yamato-Security/senrigan/blob/main/agent/requirements.txt)
 

--- a/website/docs/overview/index.es.md
+++ b/website/docs/overview/index.es.md
@@ -7,6 +7,7 @@
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](https://github.com/Yamato-Security/senrigan/blob/main/LICENSE)
 [![CI](https://github.com/Yamato-Security/senrigan/actions/workflows/ci.yml/badge.svg)](https://github.com/Yamato-Security/senrigan/actions/workflows/ci.yml)
 [![Docker](https://img.shields.io/badge/docker-compose-blue)](https://github.com/Yamato-Security/senrigan/blob/main/docker/docker-compose.yml)
+[![DEFCON](https://img.shields.io/badge/DEFCON-2026-red)](https://defcon.org/html/defcon-34/dc-34-demolabs.html#content_66521)
 [![Rust](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](https://github.com/Yamato-Security/senrigan/blob/main/ingester/Cargo.toml)
 [![Python](https://img.shields.io/badge/python-3.14%2B-blue.svg)](https://github.com/Yamato-Security/senrigan/blob/main/agent/requirements.txt)
 

--- a/website/docs/overview/index.fr.md
+++ b/website/docs/overview/index.fr.md
@@ -7,6 +7,7 @@
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](https://github.com/Yamato-Security/senrigan/blob/main/LICENSE)
 [![CI](https://github.com/Yamato-Security/senrigan/actions/workflows/ci.yml/badge.svg)](https://github.com/Yamato-Security/senrigan/actions/workflows/ci.yml)
 [![Docker](https://img.shields.io/badge/docker-compose-blue)](https://github.com/Yamato-Security/senrigan/blob/main/docker/docker-compose.yml)
+[![DEFCON](https://img.shields.io/badge/DEFCON-2026-red)](https://defcon.org/html/defcon-34/dc-34-demolabs.html#content_66521)
 [![Rust](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](https://github.com/Yamato-Security/senrigan/blob/main/ingester/Cargo.toml)
 [![Python](https://img.shields.io/badge/python-3.14%2B-blue.svg)](https://github.com/Yamato-Security/senrigan/blob/main/agent/requirements.txt)
 

--- a/website/docs/overview/index.hi.md
+++ b/website/docs/overview/index.hi.md
@@ -7,6 +7,7 @@
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](https://github.com/Yamato-Security/senrigan/blob/main/LICENSE)
 [![CI](https://github.com/Yamato-Security/senrigan/actions/workflows/ci.yml/badge.svg)](https://github.com/Yamato-Security/senrigan/actions/workflows/ci.yml)
 [![Docker](https://img.shields.io/badge/docker-compose-blue)](https://github.com/Yamato-Security/senrigan/blob/main/docker/docker-compose.yml)
+[![DEFCON](https://img.shields.io/badge/DEFCON-2026-red)](https://defcon.org/html/defcon-34/dc-34-demolabs.html#content_66521)
 [![Rust](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](https://github.com/Yamato-Security/senrigan/blob/main/ingester/Cargo.toml)
 [![Python](https://img.shields.io/badge/python-3.14%2B-blue.svg)](https://github.com/Yamato-Security/senrigan/blob/main/agent/requirements.txt)
 

--- a/website/docs/overview/index.id.md
+++ b/website/docs/overview/index.id.md
@@ -7,6 +7,7 @@
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](https://github.com/Yamato-Security/senrigan/blob/main/LICENSE)
 [![CI](https://github.com/Yamato-Security/senrigan/actions/workflows/ci.yml/badge.svg)](https://github.com/Yamato-Security/senrigan/actions/workflows/ci.yml)
 [![Docker](https://img.shields.io/badge/docker-compose-blue)](https://github.com/Yamato-Security/senrigan/blob/main/docker/docker-compose.yml)
+[![DEFCON](https://img.shields.io/badge/DEFCON-2026-red)](https://defcon.org/html/defcon-34/dc-34-demolabs.html#content_66521)
 [![Rust](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](https://github.com/Yamato-Security/senrigan/blob/main/ingester/Cargo.toml)
 [![Python](https://img.shields.io/badge/python-3.14%2B-blue.svg)](https://github.com/Yamato-Security/senrigan/blob/main/agent/requirements.txt)
 

--- a/website/docs/overview/index.ja.md
+++ b/website/docs/overview/index.ja.md
@@ -7,6 +7,7 @@
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](https://github.com/Yamato-Security/senrigan/blob/main/LICENSE)
 [![CI](https://github.com/Yamato-Security/senrigan/actions/workflows/ci.yml/badge.svg)](https://github.com/Yamato-Security/senrigan/actions/workflows/ci.yml)
 [![Docker](https://img.shields.io/badge/docker-compose-blue)](https://github.com/Yamato-Security/senrigan/blob/main/docker/docker-compose.yml)
+[![DEFCON](https://img.shields.io/badge/DEFCON-2026-red)](https://defcon.org/html/defcon-34/dc-34-demolabs.html#content_66521)
 [![Rust](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](https://github.com/Yamato-Security/senrigan/blob/main/ingester/Cargo.toml)
 [![Python](https://img.shields.io/badge/python-3.14%2B-blue.svg)](https://github.com/Yamato-Security/senrigan/blob/main/agent/requirements.txt)
 

--- a/website/docs/overview/index.ko.md
+++ b/website/docs/overview/index.ko.md
@@ -7,6 +7,7 @@
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](https://github.com/Yamato-Security/senrigan/blob/main/LICENSE)
 [![CI](https://github.com/Yamato-Security/senrigan/actions/workflows/ci.yml/badge.svg)](https://github.com/Yamato-Security/senrigan/actions/workflows/ci.yml)
 [![Docker](https://img.shields.io/badge/docker-compose-blue)](https://github.com/Yamato-Security/senrigan/blob/main/docker/docker-compose.yml)
+[![DEFCON](https://img.shields.io/badge/DEFCON-2026-red)](https://defcon.org/html/defcon-34/dc-34-demolabs.html#content_66521)
 [![Rust](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](https://github.com/Yamato-Security/senrigan/blob/main/ingester/Cargo.toml)
 [![Python](https://img.shields.io/badge/python-3.14%2B-blue.svg)](https://github.com/Yamato-Security/senrigan/blob/main/agent/requirements.txt)
 

--- a/website/docs/overview/index.md
+++ b/website/docs/overview/index.md
@@ -7,6 +7,7 @@
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](https://github.com/Yamato-Security/senrigan/blob/main/LICENSE)
 [![CI](https://github.com/Yamato-Security/senrigan/actions/workflows/ci.yml/badge.svg)](https://github.com/Yamato-Security/senrigan/actions/workflows/ci.yml)
 [![Docker](https://img.shields.io/badge/docker-compose-blue)](https://github.com/Yamato-Security/senrigan/blob/main/docker/docker-compose.yml)
+[![DEFCON](https://img.shields.io/badge/DEFCON-2026-red)](https://defcon.org/html/defcon-34/dc-34-demolabs.html#content_66521)
 [![Rust](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](https://github.com/Yamato-Security/senrigan/blob/main/ingester/Cargo.toml)
 [![Python](https://img.shields.io/badge/python-3.14%2B-blue.svg)](https://github.com/Yamato-Security/senrigan/blob/main/agent/requirements.txt)
 

--- a/website/docs/overview/index.my.md
+++ b/website/docs/overview/index.my.md
@@ -7,6 +7,7 @@
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](https://github.com/Yamato-Security/senrigan/blob/main/LICENSE)
 [![CI](https://github.com/Yamato-Security/senrigan/actions/workflows/ci.yml/badge.svg)](https://github.com/Yamato-Security/senrigan/actions/workflows/ci.yml)
 [![Docker](https://img.shields.io/badge/docker-compose-blue)](https://github.com/Yamato-Security/senrigan/blob/main/docker/docker-compose.yml)
+[![DEFCON](https://img.shields.io/badge/DEFCON-2026-red)](https://defcon.org/html/defcon-34/dc-34-demolabs.html#content_66521)
 [![Rust](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](https://github.com/Yamato-Security/senrigan/blob/main/ingester/Cargo.toml)
 [![Python](https://img.shields.io/badge/python-3.14%2B-blue.svg)](https://github.com/Yamato-Security/senrigan/blob/main/agent/requirements.txt)
 

--- a/website/docs/overview/index.pt-BR.md
+++ b/website/docs/overview/index.pt-BR.md
@@ -7,6 +7,7 @@
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](https://github.com/Yamato-Security/senrigan/blob/main/LICENSE)
 [![CI](https://github.com/Yamato-Security/senrigan/actions/workflows/ci.yml/badge.svg)](https://github.com/Yamato-Security/senrigan/actions/workflows/ci.yml)
 [![Docker](https://img.shields.io/badge/docker-compose-blue)](https://github.com/Yamato-Security/senrigan/blob/main/docker/docker-compose.yml)
+[![DEFCON](https://img.shields.io/badge/DEFCON-2026-red)](https://defcon.org/html/defcon-34/dc-34-demolabs.html#content_66521)
 [![Rust](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](https://github.com/Yamato-Security/senrigan/blob/main/ingester/Cargo.toml)
 [![Python](https://img.shields.io/badge/python-3.14%2B-blue.svg)](https://github.com/Yamato-Security/senrigan/blob/main/agent/requirements.txt)
 

--- a/website/docs/overview/index.th.md
+++ b/website/docs/overview/index.th.md
@@ -7,6 +7,7 @@
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](https://github.com/Yamato-Security/senrigan/blob/main/LICENSE)
 [![CI](https://github.com/Yamato-Security/senrigan/actions/workflows/ci.yml/badge.svg)](https://github.com/Yamato-Security/senrigan/actions/workflows/ci.yml)
 [![Docker](https://img.shields.io/badge/docker-compose-blue)](https://github.com/Yamato-Security/senrigan/blob/main/docker/docker-compose.yml)
+[![DEFCON](https://img.shields.io/badge/DEFCON-2026-red)](https://defcon.org/html/defcon-34/dc-34-demolabs.html#content_66521)
 [![Rust](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](https://github.com/Yamato-Security/senrigan/blob/main/ingester/Cargo.toml)
 [![Python](https://img.shields.io/badge/python-3.14%2B-blue.svg)](https://github.com/Yamato-Security/senrigan/blob/main/agent/requirements.txt)
 

--- a/website/docs/overview/index.tr.md
+++ b/website/docs/overview/index.tr.md
@@ -7,6 +7,7 @@
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](https://github.com/Yamato-Security/senrigan/blob/main/LICENSE)
 [![CI](https://github.com/Yamato-Security/senrigan/actions/workflows/ci.yml/badge.svg)](https://github.com/Yamato-Security/senrigan/actions/workflows/ci.yml)
 [![Docker](https://img.shields.io/badge/docker-compose-blue)](https://github.com/Yamato-Security/senrigan/blob/main/docker/docker-compose.yml)
+[![DEFCON](https://img.shields.io/badge/DEFCON-2026-red)](https://defcon.org/html/defcon-34/dc-34-demolabs.html#content_66521)
 [![Rust](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](https://github.com/Yamato-Security/senrigan/blob/main/ingester/Cargo.toml)
 [![Python](https://img.shields.io/badge/python-3.14%2B-blue.svg)](https://github.com/Yamato-Security/senrigan/blob/main/agent/requirements.txt)
 

--- a/website/docs/overview/index.uk.md
+++ b/website/docs/overview/index.uk.md
@@ -7,6 +7,7 @@
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](https://github.com/Yamato-Security/senrigan/blob/main/LICENSE)
 [![CI](https://github.com/Yamato-Security/senrigan/actions/workflows/ci.yml/badge.svg)](https://github.com/Yamato-Security/senrigan/actions/workflows/ci.yml)
 [![Docker](https://img.shields.io/badge/docker-compose-blue)](https://github.com/Yamato-Security/senrigan/blob/main/docker/docker-compose.yml)
+[![DEFCON](https://img.shields.io/badge/DEFCON-2026-red)](https://defcon.org/html/defcon-34/dc-34-demolabs.html#content_66521)
 [![Rust](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](https://github.com/Yamato-Security/senrigan/blob/main/ingester/Cargo.toml)
 [![Python](https://img.shields.io/badge/python-3.14%2B-blue.svg)](https://github.com/Yamato-Security/senrigan/blob/main/agent/requirements.txt)
 

--- a/website/docs/overview/index.zh-TW.md
+++ b/website/docs/overview/index.zh-TW.md
@@ -7,6 +7,7 @@
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](https://github.com/Yamato-Security/senrigan/blob/main/LICENSE)
 [![CI](https://github.com/Yamato-Security/senrigan/actions/workflows/ci.yml/badge.svg)](https://github.com/Yamato-Security/senrigan/actions/workflows/ci.yml)
 [![Docker](https://img.shields.io/badge/docker-compose-blue)](https://github.com/Yamato-Security/senrigan/blob/main/docker/docker-compose.yml)
+[![DEFCON](https://img.shields.io/badge/DEFCON-2026-red)](https://defcon.org/html/defcon-34/dc-34-demolabs.html#content_66521)
 [![Rust](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](https://github.com/Yamato-Security/senrigan/blob/main/ingester/Cargo.toml)
 [![Python](https://img.shields.io/badge/python-3.14%2B-blue.svg)](https://github.com/Yamato-Security/senrigan/blob/main/agent/requirements.txt)
 


### PR DESCRIPTION
Adds a **`DEFCON | 2026`** badge right after the `docker | compose` badge, linking to the [DEF CON 34 Demo Labs listing](https://defcon.org/html/defcon-34/dc-34-demolabs.html#content_66521).

Applied consistently everywhere the badge row appears so the branding doesn't drift:

- `README.md`
- the 15 localized docs **homepages** (`website/docs/index*.md`) — the site root at https://yamato-security.github.io/senrigan/
- the 15 localized **overview** pages (`website/docs/overview/index*.md`), which carry the same badge row

Each insertion matches the file's existing badge syntax — HTML `<a><img>` on the README/homepages, Markdown `[![…]](…)` on the overview pages — and preserves indentation. Purely additive: 31 files, +31/−0.